### PR TITLE
Alternative configuration page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ the only way of presenting information.
 
 Once installed, visit
 [about:blank#solarized-config](about:blank#solarized-config)
+(or [the config page for non-Firefox browsers](https://github.com/tyost/solarized-webpages/blob/master/config.html))
 to switch between the light and dark color themes. Pages must be reloaded
 to see the new changes.
 

--- a/config.html
+++ b/config.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Solarized Webpages Configuration</title>
+  </head>
+  <body></body>
+</html>

--- a/src/ConfigurationPage.ts
+++ b/src/ConfigurationPage.ts
@@ -5,9 +5,15 @@
  *  Creates the Configuration Page.
  */
 class ConfigurationPage {
+  private bodyFinder: SingleElementFinder;
+
+  constructor() {
+    this.bodyFinder = new SingleElementFinder();
+  }
+
+
   private appendToForm(elem: Element): void {
-    var bodyFinder: SingleElementFinder = new SingleElementFinder();
-    bodyFinder.getBody().appendChild(elem);
+    this.bodyFinder.getBody().appendChild(elem);
   };
 
   private setupcolorThemeSelect(): void {
@@ -36,7 +42,13 @@ class ConfigurationPage {
     });
   };
 
+  private clearBody() {
+    this.bodyFinder.getBody().innerHTML = '';
+  }
+
   setupForm(): void {
+    this.clearBody();
+
     let elementFactory: ElementFactory = new ElementFactory();
     this.appendToForm(elementFactory.createH1('Solarized Webpages Configuration'));
     this.setupcolorThemeSelect();

--- a/src/ConfigurationPageRouter.ts
+++ b/src/ConfigurationPageRouter.ts
@@ -7,12 +7,21 @@ class ConfigurationPageRouter {
     return !!bodyFinder.getBody().children.length;
   }
 
-  private getConfigurationUrl(): string {
-    return 'about:blank#solarized-config';;
+  private getConfigurationUrls(): string[] {
+    return [
+      'about:blank#solarized-config',
+      'https://github.com/tyost/solarized-webpages/blob/master/config.html',
+      'https://github.com/tyost/solarized-webpages/blob/develop/config.html',
+      'https://github.com/tyost/solarized-webpages/blob/private-chrome-config-page/config.html'
+    ];
+  }
+
+  private isConfigurationPage(location: Location): boolean {
+    return this.getConfigurationUrls().indexOf(location.href) !== -1;
   }
 
   route(location: Location): void {
-    if (location.href === this.getConfigurationUrl() && !this.scriptAlreadyRan()) {
+    if (this.isConfigurationPage(location) && !this.scriptAlreadyRan()) {
       new ConfigurationPage().setupForm();
     }
   }

--- a/src/ConfigurationPageRouter.ts
+++ b/src/ConfigurationPageRouter.ts
@@ -2,11 +2,6 @@
  *  Decides when to show the configuration page.
  */
 class ConfigurationPageRouter {
-  private scriptAlreadyRan(): boolean {
-    var bodyFinder: SingleElementFinder = new SingleElementFinder();
-    return !!bodyFinder.getBody().children.length;
-  }
-
   private getConfigurationUrls(): string[] {
     return [
       'about:blank#solarized-config',
@@ -21,7 +16,7 @@ class ConfigurationPageRouter {
   }
 
   route(location: Location): void {
-    if (this.isConfigurationPage(location) && !this.scriptAlreadyRan()) {
+    if (this.isConfigurationPage(location)) {
       new ConfigurationPage().setupForm();
     }
   }


### PR DESCRIPTION
Add an alternative URL for the configuration page of this userscript. The original `about:blank#solarized-config` URL did not work in Chrome.
