### PR TITLE
Fix documentation configuration url

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ the only way of presenting information.
 ## Switch light and dark
 
 Once installed, visit
-[about:blank#solarized-config](about:blank#solarized-config)
-(or [the config page for non-Firefox browsers](https://github.com/tyost/solarized-webpages/blob/master/config.html))
-to switch between the light and dark color themes. Pages must be reloaded
-to see the new changes.
+[the config page](https://github.com/tyost/solarized-webpages/blob/master/config.html)
+to switch between the light and dark color themes. Reload the page to see the colors change.
 
 ## Disable recoloring for certain websites
 

--- a/src/ConfigurationPageRouter.ts
+++ b/src/ConfigurationPageRouter.ts
@@ -10,7 +10,6 @@ class ConfigurationPageRouter {
 
   private getConfigurationUrls(): string[] {
     return [
-      'about:blank#solarized-config',
       'https://github.com/tyost/solarized-webpages/blob/master/config.html',
       'https://github.com/tyost/solarized-webpages/blob/develop/config.html',
       'https://github.com/tyost/solarized-webpages/blob/private-chrome-config-page/config.html'


### PR DESCRIPTION
In Firefox, Greasemonkey scripts can no longer run on about:blank pages. To get around that problem, Firefox now uses the same GitHub config URL as Chrome.