### PR TITLE
Option to disable DOMWatch

### DIFF
--- a/src/ConfigurationData.ts
+++ b/src/ConfigurationData.ts
@@ -14,6 +14,7 @@ class ConfigurationData {
     const optionMap = new Map<string, string>();
 
     optionMap.set('colorTheme', 'dark');
+    optionMap.set('domWatch', 'enabled');
 
     return optionMap;
   }

--- a/src/ConfigurationPage.ts
+++ b/src/ConfigurationPage.ts
@@ -6,10 +6,12 @@
  */
 class ConfigurationPage {
   private bodyFinder: SingleElementFinder;
+  private elementFactory: ElementFactory;
   private data: ConfigurationData;
 
   constructor(data: ConfigurationData) {
     this.bodyFinder = new SingleElementFinder();
+    this.elementFactory = new ElementFactory();
     this.data = data;
   }
 
@@ -19,9 +21,7 @@ class ConfigurationPage {
   };
 
   private setupcolorThemeSelect(): void {
-    let elementFactory: ElementFactory = new ElementFactory();
-
-    let colorThemeLabel: HTMLLabelElement = elementFactory.createLabel(
+    let colorThemeLabel: HTMLLabelElement = this.elementFactory.createLabel(
       'color-theme-select',
       'Color Theme'
     );
@@ -29,7 +29,7 @@ class ConfigurationPage {
 
     let greasemonkey: Greasemonkey = new Greasemonkey();
 
-    let colorThemeSelect: HTMLSelectElement = elementFactory.createSelect(
+    let colorThemeSelect: HTMLSelectElement = this.elementFactory.createSelect(
       'color-theme-select',
       this.data.getValue('colorTheme'),
       {
@@ -51,8 +51,7 @@ class ConfigurationPage {
   setupForm(): void {
     this.clearBody();
 
-    let elementFactory: ElementFactory = new ElementFactory();
-    this.appendToForm(elementFactory.createH1('Solarized Webpages Configuration'));
+    this.appendToForm(this.elementFactory.createH1('Solarized Webpages Configuration'));
     this.setupcolorThemeSelect();
   };
 }

--- a/src/ConfigurationPage.ts
+++ b/src/ConfigurationPage.ts
@@ -8,39 +8,51 @@ class ConfigurationPage {
   private bodyFinder: SingleElementFinder;
   private elementFactory: ElementFactory;
   private data: ConfigurationData;
+  private greasemonkey: Greasemonkey;
 
   constructor(data: ConfigurationData) {
     this.bodyFinder = new SingleElementFinder();
     this.elementFactory = new ElementFactory();
+    this.greasemonkey = new Greasemonkey();
     this.data = data;
   }
 
+
+  private getConfigurationOptions(): any[] {
+    return [
+      {
+        data: 'colorTheme',
+        label: 'Color Theme',
+        options: {
+          light: 'Light',
+          dark: 'Dark'
+        }
+      }
+    ];
+  }
 
   private appendToForm(elem: Element): void {
     this.bodyFinder.getBody().appendChild(elem);
   };
 
-  private setupcolorThemeSelect(): void {
-    let colorThemeLabel: HTMLLabelElement = this.elementFactory.createLabel(
-      'color-theme-select',
-      'Color Theme'
-    );
-    this.appendToForm(colorThemeLabel);
+  private createOptionElements(): void {
+    this.getConfigurationOptions().forEach((option) => {
+      let label: HTMLLabelElement = this.elementFactory.createLabel(
+        option.data,
+        option.label
+      );
+      this.appendToForm(label);
 
-    let greasemonkey: Greasemonkey = new Greasemonkey();
+      let select: HTMLSelectElement = this.elementFactory.createSelect(
+        option.data,
+        this.data.getValue(option.data),
+        option.options
+      );
+      this.appendToForm(select);
 
-    let colorThemeSelect: HTMLSelectElement = this.elementFactory.createSelect(
-      'color-theme-select',
-      this.data.getValue('colorTheme'),
-      {
-        light:  'Light',
-        dark:   'Dark'
-      }
-    );
-    this.appendToForm(colorThemeSelect);
-
-    colorThemeSelect.addEventListener('change', () => {
-      greasemonkey.setValue('colorTheme', colorThemeSelect.value);
+      select.addEventListener('change', () => {
+        this.greasemonkey.setValue(option.data, select.value);
+      });
     });
   };
 
@@ -52,6 +64,6 @@ class ConfigurationPage {
     this.clearBody();
 
     this.appendToForm(this.elementFactory.createH1('Solarized Webpages Configuration'));
-    this.setupcolorThemeSelect();
+    this.createOptionElements();
   };
 }

--- a/src/ConfigurationPage.ts
+++ b/src/ConfigurationPage.ts
@@ -22,12 +22,21 @@ class ConfigurationPage {
     return [
       {
         data: 'colorTheme',
-        label: 'Color Theme',
+        label: '<b>Color Theme</b>',
         options: {
           light: 'Light',
           dark: 'Dark'
         }
-      }
+      },
+      {
+        data: 'domWatch',
+        label: '<b>DOM Watch</b><br>Recolor the page as it changes.'
+            + ' Disable to improve performance.',
+        options: {
+          enabled: 'Enabled',
+          disabled: 'Disabled'
+        }
+      },
     ];
   }
 
@@ -37,18 +46,26 @@ class ConfigurationPage {
 
   private createOptionElements(): void {
     this.getConfigurationOptions().forEach((option) => {
+      let div: HTMLDivElement = document.createElement('div');
+      div.style.marginBottom = '20px';
+
       let label: HTMLLabelElement = this.elementFactory.createLabel(
         option.data,
         option.label
       );
-      this.appendToForm(label);
+      label.style.display = 'block';
+      label.style.maxWidth = '500px';
+      div.appendChild(label);
 
       let select: HTMLSelectElement = this.elementFactory.createSelect(
         option.data,
         this.data.getValue(option.data),
         option.options
       );
-      this.appendToForm(select);
+      select.style.marginLeft = '10px';
+      div.appendChild(select);
+
+      this.appendToForm(div);
 
       select.addEventListener('change', () => {
         this.greasemonkey.setValue(option.data, select.value);

--- a/src/ElementFactory.ts
+++ b/src/ElementFactory.ts
@@ -23,6 +23,7 @@ class ElementFactory {
       HTMLSelectElement {
 
     let select: HTMLSelectElement = document.createElement('select');
+    select.id = id;
 
     for (let value in options) {
       let text: string = options[value];

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -11,22 +11,19 @@
 let onLoad = () => {
   'use strict';
 
-  // Mark elements on the page that cannot be selected by CSS alone.
-  let markers: AllElementMarkers = new AllElementMarkers();
-  markers.markAllElements();
-
-  window.addEventListener('load', () => {
-    // Mark again after styles finish loading.
+  // Obtain the configuration options or defaults from the database.
+  ConfigurationData.createFromDatabase().then((data) => {
+    // Mark elements on the page that cannot be selected by CSS alone.
+    let markers: AllElementMarkers = new AllElementMarkers();
     markers.markAllElements();
 
     // After the page loads, start rescanning and marking elements that change.
-    new DomWatch().callForAnyChange((element: Element) => {
-      markers.markElement(element);
-    });
-  });
+    if (data.getValue('domWatch') === 'enabled') {
+      new DomWatch().callForAnyChange((element: Element) => {
+        markers.markElement(element);
+      });
+    }
 
-  // Obtain the configuration options or defaults from the database.
-  ConfigurationData.createFromDatabase().then((data) => {
     // Recolor the page with CSS based on the user's configuration.
     const cssColorThemes = new CssColorThemes(data);
     new CssCode(cssColorThemes).outputCss();
@@ -35,4 +32,4 @@ let onLoad = () => {
     new ConfigurationPageRouter(data).route(window.location);
   });
 };
-window.addEventListener("DOMContentLoaded", onLoad);
+window.addEventListener("load", onLoad);


### PR DESCRIPTION
* Add an option on the configuration page to disable the code that runs every time the page changes (DOMWatch).
* Improve the appearance and ease of adding new configuration options.
* Speed up the code running on each page by delaying the coloring and marking of the page.
* Options on the configuration page now have their intended IDs.